### PR TITLE
fix: save pickems correctly, previously was saving one move behind

### DIFF
--- a/src/app/components/group/index.tsx
+++ b/src/app/components/group/index.tsx
@@ -22,13 +22,15 @@ export const Group: FC<{
 
   const moveCard = useCallback((dragIndex: number, hoverIndex: number) => {
     setCards((prevCards: GroupItem[]) => {
-      updateCurrentGroups({ [groupName]: prevCards });
-      return update(prevCards, {
+      const updatedCards = update(prevCards, {
         $splice: [
           [dragIndex, 1],
           [hoverIndex, 0, prevCards[dragIndex] as GroupItem],
         ],
       });
+      updateCurrentGroups({ [groupName]: updatedCards });
+
+      return updatedCards;
     });
 
     // eslint-disable-next-line react-hooks/exhaustive-deps


### PR DESCRIPTION
Was saving the groups to the state in the pickems file before updating the group state, which caused the saved pickems to be one move behind for every group